### PR TITLE
adding post-install annotations weights

### DIFF
--- a/charts/kotal/templates/operator/manager.deployment.yaml
+++ b/charts/kotal/templates/operator/manager.deployment.yaml
@@ -6,6 +6,9 @@ metadata:
     control-plane: controller-manager
   name: controller-manager
   namespace: kotal
+  annotations:
+    helm.sh/hook: "post-install,post-upgrade"
+    helm.sh/hook-weight: "60"
 spec:
   replicas: 1
   selector:

--- a/charts/kotal/templates/operator/selfsigned.issuer.yaml
+++ b/charts/kotal/templates/operator/selfsigned.issuer.yaml
@@ -6,5 +6,6 @@ metadata:
   namespace: kotal
   annotations:
     helm.sh/hook: "post-install,post-upgrade"
+    helm.sh/hook-weight: "30"
 spec:
   selfSigned: {}

--- a/charts/kotal/templates/operator/webhook.cert.yaml
+++ b/charts/kotal/templates/operator/webhook.cert.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: kotal
   annotations:
     helm.sh/hook: "post-install,post-upgrade"
+    helm.sh/hook-weight: "40"
 spec:
   dnsNames:
     - webhook-service.kotal.svc

--- a/charts/kotal/values.yaml
+++ b/charts/kotal/values.yaml
@@ -37,6 +37,7 @@ cert-manager:
       cpu: "10m"
       memory: "50Mi"
   webhook:
+    timeoutSeconds: 30
     resources:
       requests:
         cpu: "5m"


### PR DESCRIPTION
Adding post-hook installation weights to make sure that certificate is created and can be mounted by controller-manager

Fixes below error:
Error: INSTALLATION FAILED: failed post-install: warning: Hook post-install kotal/templates/operator/selfsigned.issuer.yaml failed: Internal error occurred: failed calling webhook "webhook.cert-manager.io": failed to call webhook: Post "https://kotal-cert-manager-webhook.cert-manager.svc:443/mutate?timeout=10s": dial tcp 10.96.247.200:443: connect: connection refused
helm.go:84: [debug] failed post-install: warning: Hook post-install kotal/templates/operator/selfsigned.issuer.yaml failed: Internal error occurred: failed calling webhook "webhook.cert-manager.io": failed to call webhook: Post "https://kotal-cert-manager-webhook.cert-manager.svc:443/mutate?timeout=10s": dial tcp 10.96.247.200:443: connect: connection refused
INSTALLATION FAILED