### PR TITLE
Chart lint and test

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -41,7 +41,7 @@ jobs:
       - name: Run chart-testing (lint)
         run: |
           echo 'validate-maintainers: false' > ct.yaml
-          ct lint --target-branch main
+          ct lint --validate-maintainers=false --target-branch main
 
       - name: Create kind cluster
         uses: helm/kind-action@v1.4.0

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -1,9 +1,6 @@
 name: Lint and Test Charts
 
 on:
-  push:
-    branches:
-      - chart-lint
   pull_request:
     branches:
       - main

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -2,9 +2,11 @@ name: Lint and Test Charts
 
 on:
   push:
-    pull_request:
-      branches:
-        - main
+    branches:
+      - chart-lint
+  pull_request:
+    branches:
+      - main
 
 jobs:
   lint-test:
@@ -40,6 +42,9 @@ jobs:
 
       - name: Create kind cluster
         uses: helm/kind-action@v1.4.0
+
+      - name: Run chart-dependency-update
+        run: helm dependency update charts/kotal
 
       - name: Run chart-testing (install)
         run: |

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -1,0 +1,56 @@
+name: Lint and Test Charts
+
+on:
+  push:
+    branches:
+      - chart-lint
+    tags:
+      - 'v*'
+    pull_request:
+      branches:
+        - main
+
+jobs:
+  lint-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v3
+        with:
+          version: v3.10.0
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.9'
+          check-latest: true
+
+      - name: Set up chart-testing
+        uses: helm/chart-testing-action@v2.3.1
+
+      - name: Add helm dependencies repositories
+        run: |
+          for dir in $(ls -d charts/*/); do
+            helm dependency list $dir 2> /dev/null | tail +2 | head -n -1 | awk '{ print "helm repo add " $1 " " $3 }' | while read cmd; do $cmd; done
+          done
+
+      - name: Run chart-testing (lint)
+        run: |
+          echo 'validate-maintainers: false' > ct.yaml
+          ct lint --target-branch main
+
+      - name: Create kind cluster
+        uses: helm/kind-action@v1.4.0
+
+      - name: Run chart-testing (install)
+        run: |
+          helm install kotal charts/kotal --create-namespace --namespace=kotal --debug
+          kubectl get pods -A
+
+      - name: clean environment
+        run: |
+          helm uninstall kotal --namespace=kotal

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -2,10 +2,6 @@ name: Lint and Test Charts
 
 on:
   push:
-    branches:
-      - chart-lint
-    tags:
-      - 'v*'
     pull_request:
       branches:
         - main
@@ -40,7 +36,6 @@ jobs:
 
       - name: Run chart-testing (lint)
         run: |
-          echo 'validate-maintainers: false' > ct.yaml
           ct lint --validate-maintainers=false --target-branch main
 
       - name: Create kind cluster
@@ -49,7 +44,9 @@ jobs:
       - name: Run chart-testing (install)
         run: |
           helm install kotal charts/kotal --create-namespace --namespace=kotal --debug
+          sleep 60
           kubectl get pods -A
+          kubectl get svc -A
 
       - name: clean environment
         run: |

--- a/charts/kotal/Chart.yaml
+++ b/charts/kotal/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: kotal
 description: Kotal transforms your Kubernetes cluster into a powerful Node as a Service, Staking as a Service, and API gateway
 type: application
-version: 1.0.1
+version: 1.0.0
 appVersion: "0.1.0"
 dependencies:
   - name: "cert-manager"

--- a/charts/kotal/Chart.yaml
+++ b/charts/kotal/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: kotal
 description: Kotal transforms your Kubernetes cluster into a powerful Node as a Service, Staking as a Service, and API gateway
 type: application
-version: 1.0.0
+version: 1.0.1
 appVersion: "0.1.0"
 dependencies:
   - name: "cert-manager"


### PR DESCRIPTION
Trigger and run ct lint and ct install on a testing kind cluster.

Workflow checks Chart.yaml file and if there's any chart version update it will run $ ct lint and $ct install to lint, install and test the chart in a local KIND cluster and prints all PODs and SVCs