### PR TITLE
update controller-manager image tag via values file

### DIFF
--- a/charts/kotal/templates/operator/manager.deployment.yaml
+++ b/charts/kotal/templates/operator/manager.deployment.yaml
@@ -46,7 +46,7 @@ spec:
             - --leader-elect
           command:
             - /manager
-          image: kotalco/kotal:v0.1.0
+          image: kotalco/kotal:{{ .Values.manager.tag }}
           livenessProbe:
             httpGet:
               path: /healthz

--- a/charts/kotal/values.yaml
+++ b/charts/kotal/values.yaml
@@ -6,6 +6,9 @@ api:
 dashboard:
   tag: "v0.1.0"
 
+manager:
+  tag: "v0.1.0"
+
 traefik:
   enabled: true
   namespaceOverride: traefik


### PR DESCRIPTION
pass cloud controller manager tags via helm values

Defaults to "v0.1.0"

To install directly:
$ helm upgrade -i kotal kotal/kotal -n kotal --create-namespace --set "manager.tag=xxxxx"  --atomic --wait --set=app.name=kotal --reuse-values