### PR TITLE
add metrics server dependency

### DIFF
--- a/charts/kotal/Chart.lock
+++ b/charts/kotal/Chart.lock
@@ -8,5 +8,8 @@ dependencies:
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
   version: 12.1.3
-digest: sha256:b6ce354b58f5cd5fdb8b8cdfb7d1b1796abdc02c35066ceea1c0aedfc1489f3a
-generated: "2022-12-12T00:09:54.388627+02:00"
+- name: metrics-server
+  repository: https://charts.bitnami.com/bitnami
+  version: 6.5.0
+digest: sha256:ced913a0b464e5191563a3c39f48f1c42043d0d5b2877bc30fe985b8b6e7fcfc
+generated: "2023-08-27T18:05:09.124674+03:00"

--- a/charts/kotal/Chart.yaml
+++ b/charts/kotal/Chart.yaml
@@ -17,3 +17,7 @@ dependencies:
     version: "12.1.3"
     repository: "https://charts.bitnami.com/bitnami"
     condition: "postgresql.enabled"
+  - name: "metrics-server"
+    version: "6.5.0"
+    repository: "https://charts.bitnami.com/bitnami"
+    condition: "metrics-server.enabled"

--- a/charts/kotal/templates/metrics-server.namespace.yaml
+++ b/charts/kotal/templates/metrics-server.namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: metrics-server
+  annotations:
+    helm.sh/hook: "pre-install"

--- a/charts/kotal/values.yaml
+++ b/charts/kotal/values.yaml
@@ -9,6 +9,10 @@ dashboard:
 manager:
   tag: "v0.1.0"
 
+metrics-server:
+  enabled: true
+  namespaceOverride: metrics-server
+
 traefik:
   enabled: true
   namespaceOverride: traefik


### PR DESCRIPTION
* Add metrics server dependency to kotal helm chart
* Create metrics-server namespace pre-installation using pre-hook
* dependency installation can be disabled using metrics-server.enabled=false setting
  * some cloud providers like GCE comes with metrics-server installed in kube-system namespace