### PR TITLE
Fix DigitalOcean minor versions auto-upgrade issues

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,7 +79,7 @@ jobs:
 
       - name: Testing and Update Kotal-Helm-Chart in DO with the new kotal-chart changes
         run: |
-          helm upgrade kotal kotal-helm-chart/charts/kotal --install --wait --namespace=kotal --create-namespace --set "staging=true" --set-string "api.tag=latest" --set=app.name=kotal --set-string "api.crossover_api_key=${{ secrets.CROSSOVER_API_KEY }}" --set-string "api.sendgrid_api_key=${{ secrets.SENDGRID_API_KEY }}" --atomic
+          helm upgrade kotal kotal-helm-chart/charts/kotal --install --wait --namespace=kotal --create-namespace --set "staging=true" --set-string "api.tag=latest" --set-string "dashboard.tag=latest" --set=app.name=kotal --set-string "api.crossover_api_key=${{ secrets.CROSSOVER_API_KEY }}" --set-string "api.sendgrid_api_key=${{ secrets.SENDGRID_API_KEY }}" --atomic
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v2
@@ -100,4 +100,4 @@ jobs:
 
       - name: Testing and Update Kotal-Helm-Chart in EKS with the new kotal-chart changes
         run: |
-          helm upgrade kotal kotal-helm-chart/charts/kotal --install --wait --namespace=kotal --create-namespace --set "staging=true" --set-string "api.tag=latest" --set=app.name=kotal --set-string "api.crossover_api_key=${{ secrets.CROSSOVER_API_KEY }}" --set-string "api.sendgrid_api_key=${{ secrets.SENDGRID_API_KEY }}" --atomic
+          helm upgrade kotal kotal-helm-chart/charts/kotal --install --wait --namespace=kotal --create-namespace --set "staging=true" --set-string "api.tag=latest" --set-string "dashboard.tag=latest" --set=app.name=kotal --set-string "api.crossover_api_key=${{ secrets.CROSSOVER_API_KEY }}" --set-string "api.sendgrid_api_key=${{ secrets.SENDGRID_API_KEY }}" --atomic

--- a/charts/kotal/values.yaml
+++ b/charts/kotal/values.yaml
@@ -79,7 +79,7 @@ cert-manager:
       cpu: "10m"
       memory: "50Mi"
   webhook:
-    timeoutSeconds: 30
+    timeoutSeconds: 29
     resources:
       requests:
         cpu: "5m"


### PR DESCRIPTION
 - Mutating webhook TimeoutSeconds > 29 blocks DO upgrade
 Update TimeoutSeconds value = 29
 
 - Update CI >> set dashboard.tag=latest in testing environments
