### PR TITLE
fix send_grid env var panic if missing

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Run chart-testing (install)
         run: |
-          helm install kotal charts/kotal --create-namespace --namespace=kotal --set-string "api.crossover_api_key=${{ secrets.CROSSOVER_API_KEY }}" --debug
+          helm install kotal charts/kotal --create-namespace --namespace=kotal --set-string "api.tag=latest" --set-string "dashboard.tag=latest" --set=app.name=kotal --set-string "api.crossover_api_key=${{ secrets.CROSSOVER_API_KEY }}" --set-string "api.send_grid_api_key=${{ secrets.SEND_GRID_API_KEY }}" --debug
           sleep 60
           kubectl get pods -A
           kubectl get svc -A

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,7 +79,7 @@ jobs:
 
       - name: Testing and Update Kotal-Helm-Chart in DO with the new kotal-chart changes
         run: |
-          helm upgrade kotal kotal-helm-chart/charts/kotal --install --wait --namespace=kotal --create-namespace --set "staging=true" --set-string "api.tag=latest" --set-string "dashboard.tag=latest" --set=app.name=kotal --set-string "api.crossover_api_key=${{ secrets.CROSSOVER_API_KEY }}" --set-string "api.sendgrid_api_key=${{ secrets.SENDGRID_API_KEY }}" --atomic
+          helm upgrade kotal kotal-helm-chart/charts/kotal --install --wait --namespace=kotal --create-namespace --set "staging=true" --set-string "api.tag=latest" --set-string "dashboard.tag=latest" --set=app.name=kotal --set-string "api.crossover_api_key=${{ secrets.CROSSOVER_API_KEY }}" --set-string "api.send_grid_api_key=${{ secrets.SEND_GRID_API_KEY }}" --atomic
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v2
@@ -100,4 +100,4 @@ jobs:
 
       - name: Testing and Update Kotal-Helm-Chart in EKS with the new kotal-chart changes
         run: |
-          helm upgrade kotal kotal-helm-chart/charts/kotal --install --wait --namespace=kotal --create-namespace --set "staging=true" --set-string "api.tag=latest" --set-string "dashboard.tag=latest" --set=app.name=kotal --set-string "api.crossover_api_key=${{ secrets.CROSSOVER_API_KEY }}" --set-string "api.sendgrid_api_key=${{ secrets.SENDGRID_API_KEY }}" --atomic
+          helm upgrade kotal kotal-helm-chart/charts/kotal --install --wait --namespace=kotal --create-namespace --set "staging=true" --set-string "api.tag=latest" --set-string "dashboard.tag=latest" --set=app.name=kotal --set-string "api.crossover_api_key=${{ secrets.CROSSOVER_API_KEY }}" --set-string "api.send_grid_api_key=${{ secrets.SEND_GRID_API_KEY }}" --atomic

--- a/charts/kotal/templates/api.deployment.yaml
+++ b/charts/kotal/templates/api.deployment.yaml
@@ -28,8 +28,8 @@ spec:
               value: https://{{ if .Values.staging }}staging-{{ end }}subscriptions.kotal.co
             - name: CROSSOVER_API_KEY
               value: "{{ .Values.api.crossover_api_key }}"
-            - name: CROSSOVER_API_KEY
-              value: "{{ .Values.api.sendgrid_api_key }}"
+            - name: SEND_GRID_API_KEY
+              value: "{{ .Values.api.send_grid_api_key }}"
             - name: CROSSOVER_PATTERN
               value: "([a-z0-9]{42})"
             - name: CROSSOVER_REMOTE_ADDRESS

--- a/charts/kotal/templates/api.deployment.yaml
+++ b/charts/kotal/templates/api.deployment.yaml
@@ -24,8 +24,6 @@ spec:
               value: production
             - name: DB_SERVER_URL
               value: "postgres://{{ .Values.postgresql.auth.username }}:{{ .Values.postgresql.auth.password }}@kotal-postgresql:5432/{{ .Values.postgresql.auth.database }}"
-            - name: SUBSCRIPTION_API_BASE_URL
-              value: https://{{ if .Values.staging }}staging-{{ end }}subscriptions.kotal.co
             - name: CROSSOVER_API_KEY
               value: "{{ .Values.api.crossover_api_key }}"
             - name: SEND_GRID_API_KEY
@@ -40,4 +38,3 @@ spec:
               memory: "100Mi"
           ports:
             - containerPort: 6000
-

--- a/charts/kotal/values.yaml
+++ b/charts/kotal/values.yaml
@@ -3,7 +3,7 @@ staging: false
 api:
   tag: "v0.2.0"
   crossover_api_key: "c7f1f03dde5fc0cab9aa53081ed08ab797ff54e52e6ff4e9a38e3e092ffcf7c5"
-  sendgrid_api_key: ""
+  send_grid_api_key: ""
 
 dashboard:
   tag: "v0.2.0"


### PR DESCRIPTION
- Fix typo, set SENDGRID_API_KEY to SEND_GRID_API_KEY

- fix SEND_GRID_API_KEY panic if missing in the latest core-api docker image.

- Update Lint-Test CI job with the new env vars.